### PR TITLE
Autofill Alerts

### DIFF
--- a/react-chrome-extension/src/options/App.tsx
+++ b/react-chrome-extension/src/options/App.tsx
@@ -141,6 +141,9 @@ const removeFile = (fileKey: string) => {
 
 function EasyAppOptions() {
 
+  const [SubmitText, SetSubmitText] = useState('Submit');
+  const [SubmitVariant, SetSubmitVariant] = useState('primary');
+
   // Personal Information Form Data
   const [PersonalInfo, setPersonalInfo] = useState([
     {
@@ -484,6 +487,13 @@ function EasyAppOptions() {
       // Trigger a function to handle loading form data (assuming it is defined)
       handleFormDataLoad();
     });
+
+    SetSubmitText('Information Saved!');
+    SetSubmitVariant('success');
+    setTimeout(() => {
+      SetSubmitText('Submit');
+      SetSubmitVariant('primary');
+    }, 3000);
   };
 
   const temp = 'Test';
@@ -550,8 +560,8 @@ function EasyAppOptions() {
           <Container>
             <Row>
               <Col>
-                <Button variant='primary' onClick={handleSubmit}>
-                  Submit
+                <Button variant={SubmitVariant} onClick={handleSubmit}>
+                  {SubmitText}
                 </Button>{' '}
               </Col>
               <Col>

--- a/react-chrome-extension/src/options/App.tsx
+++ b/react-chrome-extension/src/options/App.tsx
@@ -140,7 +140,6 @@ const removeFile = (fileKey: string) => {
 };
 
 function EasyAppOptions() {
-
   const [SubmitText, SetSubmitText] = useState('Submit');
   const [SubmitVariant, SetSubmitVariant] = useState('primary');
 
@@ -439,7 +438,7 @@ function EasyAppOptions() {
     let dataToSave = {};
 
     // Supplement Text
-    let supp = "";
+    let supp = '';
 
     // Iterate over Personal Info and trim values
     PersonalInfo.forEach((data) => {

--- a/react-chrome-extension/src/popup/App.tsx
+++ b/react-chrome-extension/src/popup/App.tsx
@@ -56,8 +56,6 @@ function EasyAppPopup() {
       if (result[fields[i]].length !== 0) {
         filled = true;
       }
-      console.log(result[fields[i]]);
-      console.log(filled);
 
       // Just stops a little early :)
       if (filled) {
@@ -70,9 +68,13 @@ function EasyAppPopup() {
       SetAutofillText('Error - Fill out Settings Page');
       SetAutofillVariant('danger');
     } else {
-      SetAutofillText('Autofill Page');
-      SetAutofillVariant('primary');
       clickAutofill();
+      SetAutofillText('Successfully Autofilled Page!');
+      SetAutofillVariant('success');
+      setTimeout(() => {
+        SetAutofillText('Autofill Page');
+        SetAutofillVariant('primary');
+      }, 3000);
     }
   };
 

--- a/react-chrome-extension/src/popup/App.tsx
+++ b/react-chrome-extension/src/popup/App.tsx
@@ -36,13 +36,18 @@ function EasyAppPopup() {
 
   // Stored Form Fields (update with options page)
   const fields = [
-    'name',
-    'major',
-    'interests',
-    'skills',
-    'experience',
-    'links',
-    'supplement',
+    'OpenAI Key',
+    'firstName',
+    'middleName',
+    'lastName',
+    'email',
+    'mobileNumber',
+    'phoneNumber',
+    'address',
+    'country',
+    'state',
+    'city',
+    'zipCode',
   ];
 
   // Checks if any settings from the settings page have been filled out

--- a/react-chrome-extension/src/popup/App.tsx
+++ b/react-chrome-extension/src/popup/App.tsx
@@ -1,6 +1,6 @@
 // This app is the popup window that has buttons for the user to triger actions, and links to the options page
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Container, Image, Button } from 'react-bootstrap';
 
 let clickSettings = () => {
@@ -31,6 +31,51 @@ let clickAutofill = () => {
 };
 
 function EasyAppPopup() {
+  const [autofillText, SetAutofillText] = useState('Autofill Page');
+  const [autofillVariant, SetAutofillVariant] = useState('primary');
+
+  // Stored Form Fields (update with options page)
+  const fields = [
+    'name',
+    'major',
+    'interests',
+    'skills',
+    'experience',
+    'links',
+    'supplement',
+  ];
+
+  // Checks if any settings from the settings page have been filled out
+  let checkAutofill = async () => {
+    let filled = false;
+
+    // Check Local storage to see if anything is filled in
+    for (let i = 0; i < fields.length; i++) {
+      const result = await chrome.storage.sync.get([fields[i]]);
+
+      if (result[fields[i]].length !== 0) {
+        filled = true;
+      }
+      console.log(result[fields[i]]);
+      console.log(filled);
+
+      // Just stops a little early :)
+      if (filled) {
+        break;
+      }
+    }
+
+    if (!filled) {
+      // Change Autofill Button when nothing is filled out
+      SetAutofillText('Error - Fill out Settings Page');
+      SetAutofillVariant('danger');
+    } else {
+      SetAutofillText('Autofill Page');
+      SetAutofillVariant('primary');
+      clickAutofill();
+    }
+  };
+
   return (
     <Container className='text-center m-1'>
       <Image
@@ -40,11 +85,11 @@ function EasyAppPopup() {
         className='mx-auto d-block w-75'
       />
       <Button
-        variant='primary'
+        variant={autofillVariant}
         className='w-100 mb-3'
         id='autofill'
-        onClick={clickAutofill}>
-        Autofill Page
+        onClick={checkAutofill}>
+        {autofillText}
       </Button>
       <Button variant='primary' className='w-100 mb-3'>
         Navigate Listings


### PR DESCRIPTION
# Pull Request

## Description

This PR messes with the popup autofill button. There are 3 "states" of the button. The first and most common state is the regular blue autofill button that does nothing and is there to look pretty. Another state is a red error button when you click it but no settings page options are filled out. Only when at least one thing is filled out (even if its just whitespace) it allows you to autofill a page. This is meant to help new users configure their settings as when they first load up the extension they may not go straight to the settings page. The third state is a nice green success button that indicates the page being auto filled. Now there is a visual queue that tells the user something happened. It is only like this for 3 seconds then it goes back to the basic blue state.

Closes #50 

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which alters existing functionality)
- [x] New feature (change which adds new functionality)
- [ ] This change requires a wiki/documentation update

## How Has This Been Tested?

It works on my machine lol

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
